### PR TITLE
Add commonform-alex annotator

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,12 @@ assert.deepEqual(
       source: 'commonform-mscd',
       url: null } ])
 
+assert.deepEqual(
+  critique({ content: [ 'Hey bro!' ] }),
+  [ { message: '\"bro\" may be insensitive',
+      level: "info",
+      path: [ 'content', 0 ],
+      source: 'commonform-alex',
+      url: null } ] )
+
 ```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var alex = require('commonform-alex')
 var archaic = require('commonform-archaic')
 var doubleplus = require('doubleplus-numbers')
 var mscd = require('commonform-mscd')
@@ -30,6 +31,7 @@ var recurse = function(form, path, annotations) {
 
 module.exports = function(form) {
   return [ ]
+    .concat(alex(form))
     .concat(archaic(form))
     .concat(mscd(form))
     .concat(doubleplus(form))

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.8.1",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (http://kemitchell.com)",
   "dependencies": {
+    "commonform-alex": "^0.3.0",
     "commonform-archaic": "^1.1.0",
     "commonform-mscd": "^0.1.0",
     "commonform-predicate": "^0.4.0",


### PR DESCRIPTION
This PR adds `commonform-alex` at 0.3.0. It needs more testing, so feel free to let this PR sit for a while. It is not in a hurry. 
- [X] "Bro" test
