### PR TITLE
Test less

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 ---
 language: "node_js"
-node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
-  - "node"
+node_js: [ "4", "5" ]
 sudo: false
+cache:
+  directories:
+    - "node_modules"


### PR DESCRIPTION
It’s 2016, so we don’t need to test on Node 0.10!
